### PR TITLE
Fix target SSH folder

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,6 @@
     },
     "forwardPorts": [8888],
     "mounts": [
-        "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/manim/.ssh,readonly"
+        "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/manim/.ssh,readonly"
     ]
 }


### PR DESCRIPTION
The base directory for target mount is already in `/home` and specifying it in mount is no longer necessary.

https://stackoverflow.com/a/68588569