### PR TITLE
Include Host Requirements and Shutdown Action to `devcontainer.json`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,10 @@
 {
     "name": "manim-dev",
     "image": "manimcommunity/manim:v0.19.0",
+    "hostRequirements": {
+        "cpus": 2,
+        "memory": "8gb"
+    },
     "features": {
         "ghcr.io/devcontainers-contrib/features/ffmpeg-apt-get:1": {},
         "ghcr.io/devcontainers/features/sshd:1": {},
@@ -25,6 +29,7 @@
         "PYTHONPATH": "${containerWorkspaceFolder}"
     },
     "forwardPorts": [8888],
+    "shutdownAction": "stopContainer",
     "mounts": [
         "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/manim/.ssh,readonly"
     ]


### PR DESCRIPTION
Although Host Requirements is not needed for this package, it's generally advisable to specify the minimum requirements for using `manim`