### PR TITLE
Add an example `.env` file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+"""
+This file is for storing secrets such as user credentials, API keys, etc.
+Make sure to NOT commit this file to avoid exposing sensitive information.
+
+To use the file, rename this file from `.env.example` to `.env`. From here,
+you can start using the environment variables using `.os`.
+
+Example Usage:
+    import os
+
+    my_auth_function(
+        username=os.getenv('EXAMPLE_KEY'),
+        password=os.getenv('EXAMPLE_KEY_2')
+    )
+"""
+
+
+EXAMPLE_KEY=Example_value
+EXAMPLE_KEY_2=Example_value_2


### PR DESCRIPTION
This is where this property comes into play:

https://github.com/KaidenFrizu/manim-workspace/blob/4ccdab9b76c10401adcd5f52c0e82d3d580e82fc/.devcontainer/devcontainer.json#L28-L30

It loads any `.env` variables locally as needed.