### PR TITLE
Specify `stable` image version when using `manim`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,18 +18,15 @@
                 "ms-toolsai.jupyter"
             ],
             "settings": {
-                "terminal.integrated.defaultProfile.linux": "bash",
-                "manim-sideview.manimExecutableVersion": "${containerEnv.MANIM_VERSION}"
+                "terminal.integrated.defaultProfile.linux": "bash"
             }
         }
     },
     "onCreateCommand": "if [ -z \"$CODESPACES\" ]; then ssh-agent; ssh-add -l; fi",
     "updateContentCommand": "pip install -r requirements.txt",
-    "postCreateCommand": "export MANIM_VERSION=$(python -c 'import manim; print(manim.__version__)')",
     "postStartCommand": "git update-index --skip-worktree .env",
     "containerEnv": {
-        "PYTHONPATH": "${containerWorkspaceFolder}",
-        "MANIM_VERSION": "v0.19.0"  // Default version, will be overridden if using stable
+        "PYTHONPATH": "${containerWorkspaceFolder}"
     },
     "forwardPorts": [8888],
     "shutdownAction": "stopContainer",


### PR DESCRIPTION
To account for future feature updates where user might want to check-out, we would be specifying `stable` in the image.

This would also need to adjust on the Sideview extension to set the Executable Version to whatever version `manim` is installed.