### PR TITLE
Remove Host Requirements in Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,6 @@
 {
     "name": "manim-dev",
     "image": "manimcommunity/manim:stable",
-    "hostRequirements": {
-        "cpus": 2,
-        "memory": "8gb"
-    },
     "features": {
         "ghcr.io/devcontainers-contrib/features/ffmpeg-apt-get:1": {},
         "ghcr.io/devcontainers/features/sshd:1": {},


### PR DESCRIPTION
Reverts #4 specifically on `hostRequirements`

I've changed my mind regarding on this because `manim` does work below the initially given requirements, though they might not have an optimal experience working under the given specs.

This would give flexibility to users on how much resource that they can allocate to running `manim`